### PR TITLE
Add NESO package to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ struggle to compile some dependencies like NumPy and Boost. You may
 need to specify those to be built using another compiler, such as the
 classic Intel compilers:
 ```
-spack isntall neso.nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel
+spack install neso.nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel
 ```
 
 For more information on using this Spack repo to develop NESO, see the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NESO-Spack
 
-To enable your installation of spack to use this repo do:
+This repository provides Spack packages for NESO and some of its
+dependencies. To enable your installation of Spack to use this repo do:
 
 ```
 git clone git@github.com:ExCALIBUR-NEPTUNE/NESO-spack.git
@@ -8,5 +9,26 @@ cd NESO-spack
 spack repo add .
 ```
 
-followed by e.g. `spack install neso.nektar@5.2.0`.
+You can then use `spack install` to build various packages. For
+example, you can build Nektar++ using GCC and OpenBLAS by running
+```
+spack install neso.nektar%gcc ^openblas
+```
+If instead you want to build it using the Intel oneAPI compilers and
+Intel MKL, you can run
+```
+spack install neso.nektar%oneapi ^intel-oneapi-mkl
+```
+These installations can coexist side-by-side.
 
+Note that the oneAPI compilers (and Clang, on which they are based)
+struggle to compile some dependencies like NumPy and Boost. You may
+need to specify those to be built using another compiler, such as the
+classic Intel compilers:
+```
+spack isntall neso.nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel
+```
+
+For more information on using this Spack repo to develop NESO, see the
+[README for that
+repository](https://github.com/ExCALIBUR-NEPTUNE/NESO).

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -136,7 +136,7 @@ class Dpcpp(Package):
         for path in self._library_paths:
             #env.append_flags("__INTEL_PRE_CFLAGS", f"-Wl,-rpath,{path}")
             env.append_path("LD_LIBRARY_PATH", str(path))
-    
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         self._setup_common_dependent_environment(env, dependent_spec)
         env.prepend_path(

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -1,0 +1,154 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# FIXME: Use os.path and builtin tools instead of pathlib
+from os import path
+from pathlib import Path
+
+from llnl.util import filesystem
+from spack import *
+
+def _increment_version(version_tuple):
+    return ".".join(map(str, version_tuple[:-1])) + "." + str(version_tuple[-1] + 1)
+
+def _decrement_version(version_tuple):
+    if len(version_tuple) == 0:
+        return None
+    if version_tuple[-1] == 0:
+        return _decrement_version(version_tuple[:-1])
+    return ".".join(map(str, version_tuple[:-1])) + "." + str(version_tuple[-1] - 1)
+
+def _restrict_to_version(version):
+    """Return a version constraint that only allos the specified version
+    """
+    ver = tuple(map(int, version.split(".")))
+    lower = _decrement_version(ver)
+    upper = _increment_version(ver)
+    if lower:
+        return ":" + lower + "," + upper + ":"
+    else:
+        return upper + ":"
+
+class Dpcpp(Package):
+    """Dummy package that configures the DPC++ implementation of SYCL. This involves setting some extra environment variables for the Intel oneAPI compilers."""
+
+    homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
+    maintainers = ["cmacmackin"]
+
+    provides("sycl")
+
+    # These are the same as the available versions of OneAPI
+    # compilers.
+    # TODO: Figure out how to get those versions
+    # programmatically from the intel-oneapi-compilers package?
+    available_versions = [
+        "2022.2.0",
+        "2022.1.0",
+        "2022.0.2",
+        "2022.0.1",
+        "2021.4.0",
+        "2021.3.0",
+        "2021.2.0",
+        "2021.1.2",
+    ]
+    for v in available_versions:
+        version(v)
+        # The version of DPC++ must be the same as that of the OneAPI compilers.
+        conflicts(
+            "%oneapi@" + _restrict_to_version(v), when="@" + v,
+            msg="DPC++ version must match that of OneAPI compilers."
+        )
+
+    # for v in versions:
+    #     print(_restrict_to_version(v))
+
+    # This is a dummy package for oneAPI, so conflicts with all other compilers
+    # FIXME: Is there a list from somewhere I can import to guarantee
+    # nothing is forgotten?
+    CONFLICTING_COMPILERS = [
+        "%aocc",
+        "%apple-clang",
+        "%arm",
+        "%cce",
+        "%clang",
+        "%dpcpp",
+        "%fj",
+        "%gcc",
+        "%intel",
+        "%msvc",
+        "%nag",
+        "%nvhpc",
+        "%pgi",
+        "%rocmcc",
+        "%xl",
+        "%xl-r",
+    ]
+
+    for comp in CONFLICTING_COMPILERS:
+        conflicts(comp, msg="DPC++ only supported by Intel oneAPI compilers.")
+
+    has_code = False
+    phases = []
+
+    @property
+    def _compiler_dir(self):
+        return Path(self.compiler.cxx).parent
+
+    @property
+    def _oneapi_root(self):
+        return self._compiler_dir.parent.parent.parent.parent
+
+    @property
+    def cmake_prefix_paths(self):
+        return [str(self._compiler_dir.parent / 'IntelDPCPP')]
+
+    @property
+    def _library_paths(self):
+        return [
+            self._oneapi_root / "tbb" / "latest" / "lib" / "intel64" / "gcc4.8",
+            self._compiler_dir.parent / "lib",
+            self._compiler_dir.parent / "lib" / "x64",
+            self._compiler_dir.parent / "lib" / "oclfpga" / "host" / "linux64" / "lib",
+            self._compiler_dir.parent / "compiler" / "lib" / "intel64_lin",
+            self._compiler_dir.parent / "lib" / "emu",
+            self._compiler_dir.parent / "lib" / "oclfpga" / "linux64" / "lib",
+            self._compiler_dir.parent / "compiler" / "lib",
+        ]
+
+    @property
+    def libs(self):
+        libs = []
+        for path in self._library_paths:
+            libs += filesystem.find_libraries("*.so*", path)
+        return libs
+    
+    def install(self):
+        pass
+
+    def _setup_common_dependent_environment(self, env, dependent_spec):
+        env.set("ONEAPI_ROOT", str(self._oneapi_root))
+        env.append_path("PATH", str(self._compiler_dir))
+        # Need to set this in order to allow DLOPEN to find backend
+        # libraries at runtime. Hopefully later releases will render
+        # this unnecessary (see
+        # https://github.com/intel/llvm/blob/sycl/sycl/doc/design/PluginInterface.md#plugin-discovery).
+        for path in self._library_paths:
+            #env.append_flags("__INTEL_PRE_CFLAGS", f"-Wl,-rpath,{path}")
+            env.append_path("LD_LIBRARY_PATH", str(path))
+    
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self._setup_common_dependent_environment(env, dependent_spec)
+        env.prepend_path(
+            "PKG_CONFIG_PATH", str(self._oneapi_root / "tbb" / "latest" / "lib" / "pkgconfig")
+        )
+        env.prepend_path(
+            "PKG_CONFIG_PATH", str(self._compiler_dir.parent.parent / "lib" / "pkgconfig")
+        )
+        env.append_path("SYCL_INCLUDE_DIR_HINT", str(self._compiler_dir.parent))
+        env.append_path("SYCL_LIBRARY_DIR_HINT", str(self._compiler_dir.parent))
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        # Not clear which of these I really need, or whether they should be run-time or build-time
+        self._setup_common_dependent_environment(env, dependent_spec)

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -21,7 +21,7 @@ def _decrement_version(version_tuple):
     return ".".join(map(str, version_tuple[:-1])) + "." + str(version_tuple[-1] - 1)
 
 def _restrict_to_version(version):
-    """Return a version constraint that only allos the specified version
+    """Return a version constraint that only allows the specified version.
     """
     ver = tuple(map(int, version.split(".")))
     lower = _decrement_version(ver)
@@ -32,7 +32,9 @@ def _restrict_to_version(version):
         return upper + ":"
 
 class Dpcpp(Package):
-    """Dummy package that configures the DPC++ implementation of SYCL. This involves setting some extra environment variables for the Intel oneAPI compilers."""
+    """Dummy package that configures the DPC++ implementation of
+    SYCL. This involves setting some extra environment variables for
+    the Intel oneAPI compilers."""
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
     maintainers = ["cmacmackin"]
@@ -60,9 +62,6 @@ class Dpcpp(Package):
             "%oneapi@" + _restrict_to_version(v), when="@" + v,
             msg="DPC++ version must match that of OneAPI compilers."
         )
-
-    # for v in versions:
-    #     print(_restrict_to_version(v))
 
     # This is a dummy package for oneAPI, so conflicts with all other compilers
     # FIXME: Is there a list from somewhere I can import to guarantee

--- a/packages/hipsycl/package.py
+++ b/packages/hipsycl/package.py
@@ -59,7 +59,7 @@ class Hipsycl(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("boost +filesystem", when="@:0.8")
-    depends_on("boost@1.67.0:1.69.0 +filesystem +fiber +context cxxstd=17", when='@0.9.1:')
+    depends_on("boost@1.60.0: +filesystem +fiber +context cxxstd=17", when='@0.9.1:')
     depends_on("python@3:")
     # depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda")

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -84,6 +84,7 @@ class Nektar(CMakePackage):
         args.append("-DNEKTAR_USE_PETSC=OFF")
         args.append("-DNEKTAR_ERROR_ON_WARNINGS=OFF")
         args.append("-DNEKTAR_USE_MKL=%s" % hasfeature("+mkl"))
+        args.append("-DNEKTAR_USE_OPENBLAS=%s" % hasfeature("^openblas"))
         args.append("-DNEKTAR_BUILD_PYTHON=%s" % hasfeature("+python"))
         args.append("-DNEKTAR_BUILD_UTILITIES=ON")
         args.append("-DNEKTAR_USE_THREAD_SAFETY=ON")

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -108,3 +108,9 @@ class Nektar(CMakePackage):
             src_path = os.path.join(self.build_directory, "setup.py")
             dst_path = os.path.join(self.spec.prefix, "setup.py")
             shutil.copyfile(src_path, dst_path)
+
+    def add_files_to_view(self, view, merge_map, skip_if_exists=True):
+        super(CMakePackage, self).add_files_to_view(view, merge_map, skip_if_exists)
+        path = self.view_destination(view)
+        print(path)
+        view.link(os.path.join(path, "lib64", "nektar++"), os.path.join(path, "lib", "nektar++"))

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -89,17 +89,11 @@ class Nektar(CMakePackage):
         args.append("-DNEKTAR_USE_THREAD_SAFETY=ON")
         return args
 
-    def setup_run_environment(self, env):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         env.append_path(
             "CMAKE_PREFIX_PATH",
             os.path.join(self.spec.prefix, os.path.join("lib64", os.path.join("nektar++", "cmake"))),
         )
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
-    def setup_build_environment(self, env):
-        pass
 
     @run_after("install")
     def copy_cmake_files(self):

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -42,30 +42,28 @@ class Nektar(CMakePackage):
     depends_on("cmake@2.8.8:", type="build", when="~hdf5")
     depends_on("cmake@3.2:", type="build", when="+hdf5")
 
-    depends_on("blas", type=("build", "link", "run"))
-    depends_on("tinyxml", when="+tinyxml", type=("build", "link", "run"))
-    depends_on("lapack", type=("build", "link", "run"))
+    depends_on("blas")
+    depends_on("tinyxml", when="+tinyxml")
+    depends_on("lapack")
     # Last version supporting C++11
     depends_on(
-        "boost@1.74.0 +thread +iostreams +filesystem +system +program_options +regex +pic +python",
+        "boost@1.74.0: +thread +iostreams +filesystem +system +program_options +regex +pic +python +numpy",
         when="+python",
-        type=("build", "link", "run"),
     )
     depends_on(
-        "boost@1.74.0 +thread +iostreams +filesystem +system +program_options +regex +pic",
+        "boost@1.74.0: +thread +iostreams +filesystem +system +program_options +regex +pic",
         when="~python",
-        type=("build", "link", "run"),
     )
-    depends_on("tinyxml", when="platform=darwin", type=("build", "link", "run"))
+    depends_on("tinyxml", when="platform=darwin")
 
     depends_on("mpi", when="+mpi", type=("build", "link", "run"))
-    depends_on("fftw@3.0: +mpi", when="+mpi+fftw", type=("build", "link", "run"))
-    depends_on("fftw@3.0: ~mpi", when="~mpi+fftw", type=("build", "link", "run"))
-    depends_on("arpack-ng +mpi", when="+arpack+mpi", type=("build", "link", "run"))
-    depends_on("arpack-ng ~mpi", when="+arpack~mpi", type=("build", "link", "run"))
-    depends_on("hdf5 +mpi +hl", when="+mpi+hdf5", type=("build", "link", "run"))
-    depends_on("scotch ~mpi ~metis", when="~mpi+scotch", type=("build", "link", "run"))
-    depends_on("scotch +mpi ~metis", when="+mpi+scotch", type=("build", "link", "run"))
+    depends_on("fftw@3.0: +mpi", when="+mpi+fftw")
+    depends_on("fftw@3.0: ~mpi", when="~mpi+fftw")
+    depends_on("arpack-ng +mpi", when="+arpack+mpi")
+    depends_on("arpack-ng ~mpi", when="+arpack~mpi")
+    depends_on("hdf5 +mpi +hl", when="+mpi+hdf5")
+    depends_on("scotch ~mpi ~metis", when="~mpi+scotch")
+    depends_on("scotch +mpi ~metis", when="+mpi+scotch")
     depends_on("python@3:", when="+python", type=("build", "link", "run"))
 
     conflicts("+hdf5", when="~mpi", msg="Nektar's hdf5 output is for parallel builds only")

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -90,11 +90,17 @@ class Nektar(CMakePackage):
         args.append("-DNEKTAR_USE_THREAD_SAFETY=ON")
         return args
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_run_environment(self, env):
         env.append_path(
             "CMAKE_PREFIX_PATH",
             os.path.join(self.spec.prefix, os.path.join("lib64", os.path.join("nektar++", "cmake"))),
         )
+
+    def setup_dependent_run_environment(self, env):
+        self.setup_run_environment(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
 
     @run_after("install")
     def copy_cmake_files(self):

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -80,7 +80,7 @@ class Nektar(CMakePackage):
         args.append("-DNEKTAR_USE_SCOTCH=%s" % hasfeature("+scotch"))
         args.append("-DNEKTAR_USE_PETSC=OFF")
         args.append("-DNEKTAR_ERROR_ON_WARNINGS=OFF")
-        args.append("-DNEKTAR_USE_MKL=%s" % hasfeature("%intel-oneapi-mkl"))
+        args.append("-DNEKTAR_USE_MKL=%s" % hasfeature("^intel-oneapi-mkl"))
         args.append("-DNEKTAR_USE_OPENBLAS=%s" % hasfeature("^openblas"))
         args.append("-DNEKTAR_BUILD_PYTHON=%s" % hasfeature("+python"))
         args.append("-DNEKTAR_BUILD_UTILITIES=ON")

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -96,7 +96,7 @@ class Nektar(CMakePackage):
             os.path.join(self.spec.prefix, os.path.join("lib64", os.path.join("nektar++", "cmake"))),
         )
 
-    def setup_dependent_run_environment(self, env):
+    def setup_dependent_run_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
 
     def setup_dependent_build_environment(self, env, dependent_spec):

--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -34,7 +34,6 @@ class Nektar(CMakePackage):
     variant("scotch", default=True, description="Builds with scotch partitioning support")
     variant("demos", default=True, description="Build demonstration codes")
     variant("solvers", default=True, description="Build example solvers")
-    variant("mkl", default=False, description="Enable MKL")
     variant("python", default=True, description="Enable python support")
 
     depends_on("cmake@2.8.8:", type="build", when="~hdf5")
@@ -81,7 +80,7 @@ class Nektar(CMakePackage):
         args.append("-DNEKTAR_USE_SCOTCH=%s" % hasfeature("+scotch"))
         args.append("-DNEKTAR_USE_PETSC=OFF")
         args.append("-DNEKTAR_ERROR_ON_WARNINGS=OFF")
-        args.append("-DNEKTAR_USE_MKL=%s" % hasfeature("+mkl"))
+        args.append("-DNEKTAR_USE_MKL=%s" % hasfeature("%intel-oneapi-mkl"))
         args.append("-DNEKTAR_USE_OPENBLAS=%s" % hasfeature("^openblas"))
         args.append("-DNEKTAR_BUILD_PYTHON=%s" % hasfeature("+python"))
         args.append("-DNEKTAR_BUILD_UTILITIES=ON")

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -54,7 +54,7 @@ class Neso(CMakePackage):
     depends_on("fftw-api", type="link")
     depends_on("nektar", type="link")
     depends_on("cmake@3.14:", type="build")
-    depends_on("boost@1.78:", type="test")
+    depends_on("boost@1.74:", type="test")
 
     conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -1,0 +1,95 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install neso
+#
+# You can edit this file again by typing:
+#
+#     spack edit neso
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+class Neso(CMakePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/ExCALIBUR-NEPTUNE"
+    git = "https://github.com/ExCALIBUR-NEPTUNE/NESO"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    maintainers = ["jwscook", "will-saunders-ukaea", "cmacmackin"]
+
+    version('working', branch='main')
+    version('main', branch='main')
+
+    variant(
+        "fft",
+        default="fftw",
+        description="Library to use for FFTs",
+        values=("fftw", "mkl"),
+    )
+    # FIXME: This should be a virtual package dependency, but Spack
+    # doesn't seem to realise that intel-oneapi-compilers provides it
+    # yet.
+    variant(
+        "sycl",
+        default="hipsycl",
+        description="SYCL implementation to compile with",
+        values=("hipsycl", "oneapi"),
+    )
+    # variant(
+    #     "sanitizer",
+    #     description="The sanitizers to compile with",
+    #     values=spack.variant.disjoint_sets(
+    #         ("address", "leak", "undefined_behaviour"),
+    #         ("thread", "undefined_behaviour"),
+    #         ("memory", "undefined_behaviour"),
+    #     ).with_default("none").with_error(
+    #         "'thread' and 'memory' can not be combined with each other or with "
+    #         "'address' or 'leak'"
+    #     ),
+    # )
+    variant(
+        "coverage", default=False, description="Enable coverage reporting for GCC/Clang"
+    )
+
+    # FIXME: Use virtual SYCL package
+    depends_on("hipsycl", when="sycl=hipsycl")
+    # FIXME: the onapi packages don't seem to configure the run
+    # environment at all, meaning the computer can't find anything in
+    # Intel's non-standard places. Also, should probably treat this as
+    # a _compiler_ choice rather than a normal dependency.
+    depends_on("intel-oneapi-compilers", when="sycl=oneapi", type="build")
+    depends_on("intel-oneapi-dpl", when="sycl=oneapi")
+    depends_on("intel-oneapi-tbb", when="sycl=oneapi")
+    depends_on("fftw", when="fft=fftw")
+    depends_on("intel-oneapi-mkl", when="fft=mkl")
+    depends_on("nektar")
+    depends_on("cmake@3.14:", type="build")
+    depends_on("boost@1.78:", type="test")
+
+    def cmake_args(self):
+        args = []
+        # for value in self.spec.variants['sanitizer'].value:
+        #     if value != "none":
+        #         args.append(f"-DENABLE_SANITIZER_{value.toupper()}=ON")
+        if "+coverage" in self.spec:
+            args.append("-DENABLE_COVERAGE=ON")
+        # if "sycl=oneapi" in self.spec:
+        #     args.append(f"-DIntelDPCPP_DIR={self.spec['intel-oneapi-compilers'].prefix}/compiler/latest/linux/IntelDPCPP")
+        #     args.append(f"-DCMAKE_CXX_COMPILER={self.spec['intel-oneapi-compilers'].prefix}/compiler/latest/linux/bin/icpx")
+        return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -70,7 +70,15 @@ class Neso(CMakePackage):
                 args.append(f"-DENABLE_SANITIZER_{value.upper()}=ON")
         if "+coverage" in self.spec:
             args.append("-DENABLE_COVERAGE=ON")
-        if 'intel' in self.spec['mpi'].name:
+        if "intel" in self.spec["mpi"].name:
             if "I_MPI_FABRICS" not in environ:
-                warn("The intel mpi specific environment variable, I_MPI_FABRICS, has not been set and an intel-MPI build will fail. If you are developing on an unmanaged-HPC machine, i.e. locally on your workstation, a sensible default `export I_MPI_FABRICS=shm`. Information can be found on the intel documentation pages https://tinyurl.com/33w8x8wp", UserWarning, stacklevel=1)
+                warn("The intel mpi specific environment variable, I_MPI_FABRICS, has not been set and an intel-MPI build will fail. If you are developing on an unmanaged-HPC machine, i.e. locally on your workstation, a sensible default `export I_MPI_FABRICS=shm`. Information can be found on the intel documentation pages https://tinyurl.com/33w8x8wp.", UserWarning, stacklevel=1)
+        for depspec in  self.spec.dependencies():
+            for dep in depspec.dependents():
+                if "sycl" in dep:
+                    if "SYCL_DEVICE_FILTER" not in environ:
+                        warn("The environment variable SYCL_DEVICE_FILTER is not set and the code may not run as intended in this environment. A sensible default for running on the cpu is `export SYCL_DEVICE_FILTER=host`. For more information please see e.g. https://tinyurl.com/y37672as.", UserWarning, stacklevel=1)
+
+                    break
+
         return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install neso
-#
-# You can edit this file again by typing:
-#
-#     spack edit neso
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 from spack.error import SpecError
 
@@ -40,14 +23,14 @@ def _validate_sanitizer_variant(pkg_name, variant_name, values):
     
 
 class Neso(CMakePackage):
-    """FIXME: Put a proper description of your package here."""
+    """This is a test implmentation of a PIC solver for 1+1D Vlasov
+    Poisson, written in C++/DPC++. This is primarily designed to test
+    the use of multiple repos/workflows for different code
+    components."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/ExCALIBUR-NEPTUNE"
     git = "https://github.com/ExCALIBUR-NEPTUNE/NESO"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
     maintainers = ["jwscook", "will-saunders-ukaea", "cmacmackin"]
 
     version('working', branch='main')
@@ -56,7 +39,7 @@ class Neso(CMakePackage):
     variant(
         "sanitizer",
         description="The sanitizers to compile with",
-        values=("address", "leak", "thread", "memory", "undefined_behaviour"),
+        values=("none", "address", "leak", "thread", "memory", "undefined_behaviour"),
         default="none",
         multi=True,
         validator=_validate_sanitizer_variant,
@@ -65,27 +48,23 @@ class Neso(CMakePackage):
         "coverage", default=False, description="Enable coverage reporting for GCC/Clang"
     )
 
-    depends_on("sycl", type=("build", "link", "run"))
-    depends_on("intel-oneapi-dpl", when="^dpcpp")
-    depends_on("fftw-api")
-    depends_on("nektar")
+    # Some SYCL packages require a specific run-time environment to be set
+    depends_on("sycl", type=("build", "link"))
+    depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
+    depends_on("fftw-api", type="link")
+    depends_on("nektar", type="link")
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.78:", type="test")
 
-    conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp itself.")
-    # This should really be set in teh MKL package itself...
+    conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
+    # This should really be set in the MKL package itself...
     conflicts("^intel-oneapi-mkl@2022.2", when="%oneapi@:2022.1", msg="Use the same version of MKL and OneAPI compilers.")
-
-    # Should these go here? In principle these may be buildable on
-    # some systems or with some versions.
-    conflicts("^py-numpy%oneapi", msg="Requires too much RAM to build Numpy with OneAPI compilers.")
-    conflicts("^boost%oneapi", msg="Requires too much RAM to build Boost with OneAPI compilers.")
 
     def cmake_args(self):
         args = []
         for value in self.spec.variants['sanitizer'].value:
             if value != "none":
-                args.append(f"-DENABLE_SANITIZER_{value.toupper()}=ON")
+                args.append(f"-DENABLE_SANITIZER_{value.upper()}=ON")
         if "+coverage" in self.spec:
             args.append("-DENABLE_COVERAGE=ON")
         return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from os import environ
 from spack.package import *
 from spack.error import SpecError
+from warnings import warn
 
 def _validate_sanitizer_variant(pkg_name, variant_name, values):
     """Checks that the combination of sanitizer types is valid."""
@@ -68,4 +70,7 @@ class Neso(CMakePackage):
                 args.append(f"-DENABLE_SANITIZER_{value.upper()}=ON")
         if "+coverage" in self.spec:
             args.append("-DENABLE_COVERAGE=ON")
+        if 'intel' in self.spec['mpi'].name:
+            if "I_MPI_FABRICS" not in environ:
+                warn("The intel mpi specific environment variable, I_MPI_FABRICS, has not been set and an intel-MPI build will fail. If you are developing on an unmanaged-HPC machine, i.e. locally on your workstation, a sensible default `export I_MPI_FABRICS=shm`. Information can be found on the intel documentation pages https://tinyurl.com/33w8x8wp", UserWarning, stacklevel=1)
         return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -56,9 +56,10 @@ class Neso(CMakePackage):
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.78:", type="test")
 
-    conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
+        conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...
     conflicts("^intel-oneapi-mkl@2022.2", when="%oneapi@:2022.1", msg="Use the same version of MKL and OneAPI compilers.")
+    conflicts("^dpcpp", when="%gcc", msg="DPC++ can only be used with Intel oneAPI compilers.")
 
     def cmake_args(self):
         args = []

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -56,7 +56,7 @@ class Neso(CMakePackage):
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.78:", type="test")
 
-        conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
+    conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...
     conflicts("^intel-oneapi-mkl@2022.2", when="%oneapi@:2022.1", msg="Use the same version of MKL and OneAPI compilers.")
     conflicts("^dpcpp", when="%gcc", msg="DPC++ can only be used with Intel oneAPI compilers.")


### PR DESCRIPTION
A Spack package has been written for NESO. This allows Spack to install it. It also allows us to easily ensure Spack will install all of the correct dependencies. Some modifications were made to the dependency packages to help facilitate this.