### PR TITLE
Update package.py

### DIFF
--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -69,6 +69,8 @@ class Neso(CMakePackage):
             self.define("ENABLE_NESO_TESTS", self.run_tests),
             self.define_from_variant("ENABLE_COVERAGE", "coverage"),
         ]
+        # The line below is a work around for https://github.com/spack/spack/issues/29447
+        args.append("-DENABLE_NESO_TESTS:BOOL=ON") # TODO: Fix, issue NESO#128
         for value in self.spec.variants['sanitizer'].value:
             if value != "none":
                 args.append(f"-DENABLE_SANITIZER_{value.upper()}=ON")

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -65,12 +65,18 @@ class Neso(CMakePackage):
     conflicts("^dpcpp", when="%gcc", msg="DPC++ can only be used with Intel oneAPI compilers.")
 
     def cmake_args(self):
+        # Ideally we would only build the tests when Spack is going to
+        # run them. However, Spack's testing is currently broken in
+        # environments (see
+        # https://github.com/spack/spack/issues/29447), so we we will
+        # build the tests unconditionally until that is resolved.
+        #
+        # TODO: Fix, issue NESO#128
         args = [
-            self.define("ENABLE_NESO_TESTS", self.run_tests),
+            # self.define("ENABLE_NESO_TESTS", self.run_tests),
             self.define_from_variant("ENABLE_COVERAGE", "coverage"),
         ]
-        # The line below is a work around for https://github.com/spack/spack/issues/29447
-        args.append("-DENABLE_NESO_TESTS:BOOL=ON") # TODO: Fix, issue NESO#128
+        
         for value in self.spec.variants['sanitizer'].value:
             if value != "none":
                 args.append(f"-DENABLE_SANITIZER_{value.upper()}=ON")


### PR DESCRIPTION
This configures spack to always build the neso tests because spack has a bug, https://github.com/spack/spack/issues/29447, which prevents the `spack install --test root` from building the tests optionally. 

Encountered in https://github.com/ExCALIBUR-NEPTUNE/NESO/pull/118 and issued in https://github.com/ExCALIBUR-NEPTUNE/NESO/issues/128.