### PR TITLE
Fix super calls in Nektar package

### DIFF
--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -150,10 +150,10 @@ class Nektar(CMakePackage):
         src_path = os.path.join(self.stage.path, self.stage.source_path)
         dst_path = self.copied_build_dir
         shutil.copytree(src_path, dst_path)
-        super(type(self), self).cmake(spec, prefix)
+        super(Nektar, self).cmake(spec, prefix)
 
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
-        super(type(self), self).add_files_to_view(view, merge_map, skip_if_exists)
+        super(Nektar, self).add_files_to_view(view, merge_map, skip_if_exists)
         path = self.view_destination(view)
         print(path)
         view.link(os.path.join(path, "lib64", "nektar++"), os.path.join(path, "lib", "nektar++"))


### PR DESCRIPTION
Fixes an issue with the Nektar package which meant calls like `super(type(self), self).<method>` were resolving to `self.<method>`, causing unintended recursion.
This was showing up as a FileExistsError because the file copy in Nektar.cmake() was repeated.
