### PR TITLE
Pin Scotch version to 6.0.4 when building Nektar

### DIFF
--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -72,8 +72,8 @@ class Nektar(CMakePackage):
     depends_on("arpack-ng +mpi", when="+arpack+mpi")
     depends_on("arpack-ng ~mpi", when="+arpack~mpi")
     depends_on("hdf5 +mpi +hl", when="+mpi+hdf5")
-    depends_on("scotch ~mpi ~metis", when="~mpi+scotch")
-    depends_on("scotch +mpi ~metis", when="+mpi+scotch")
+    depends_on("scotch@6.0.4 ~mpi ~metis", when="~mpi+scotch")
+    depends_on("scotch@6.0.4 +mpi ~metis", when="+mpi+scotch")
     depends_on("python@3:", when="+python", type=("build", "link", "run"))
 
     conflicts("+hdf5", when="~mpi", msg="Nektar's hdf5 output is for parallel builds only")


### PR DESCRIPTION
Fixes Nektar's Scotch dependence to version 6.0.4.
With Scotch 7.0.1 (Spack's default), running with certain global solve modes, often the default, causes a segfault.
While this can be avoided by setting a suitable 'GlobalSysSoln' in the config file, I'd argue it's better to just rollback the version and not have to worry about it.

N.B.
- 6.0.4 is the version that Nektar itself builds if configured with -DBUILD_THIRDPARTY_SCOTCH
