### PR TITLE
Ensure gmock included with googletest

### DIFF
--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -57,7 +57,7 @@ class Neso(CMakePackage):
     depends_on("nektar+compflow_solver", type="link")
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.74:", type="test")
-    depends_on("googletest", type="link")
+    depends_on("googletest+gmock", type="link")
 
     conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...


### PR DESCRIPTION
Sets the +gmock variant of googletest as a NESO dependency.
This is required by ExCALIBUR-NEPTUNE/NESO#116.