### PR TITLE
Build nektar in standard Spack locations

### DIFF
--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -82,13 +82,6 @@ class Nektar(CMakePackage):
 
     conflicts("+hdf5", when="~mpi", msg="Nektar's hdf5 output is for parallel builds only")
 
-    @property
-    def install_targets(self):
-        targets = ["install"]
-        if "+python" in self.spec:
-            targets.append("nekpy-install-system")
-        return targets
-
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
For some reason, the Nektar++ source was being copied to a directory in the install-tree and built there. This meant the installation was unnecessarily large (as it contained build artefacts) and also caused problems when trying to build Nektar++ using the development workflow. For that, CMake was being run in the top-level directory of the repository, before the copying took place (for some reason). This caused problems when it was rerun with a different compiler/toolchain.