### PR TITLE
Set Dpcpp package versions automatically

### DIFF
--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -10,6 +10,12 @@ from pathlib import Path
 from llnl.util import filesystem
 from spack import *
 
+def _get_pkg_versions(pkg_name):
+    pkg_spec = spack.spec.Spec(pkg_name)
+    pkg_cls  = spack.repo.path.get_pkg_class(pkg_name)
+    pkg      = pkg_cls(pkg_spec)
+    return sorted([vkey.string for vkey in pkg.versions.keys()])
+
 def _increment_version(version_tuple):
     return ".".join(map(str, version_tuple[:-1])) + "." + str(version_tuple[-1] + 1)
 
@@ -43,19 +49,7 @@ class Dpcpp(Package):
 
     # These are the same as the available versions of OneAPI
     # compilers.
-    # TODO: Figure out how to get those versions
-    # programmatically from the intel-oneapi-compilers package?
-    available_versions = [
-        "2022.2.1",
-        "2022.2.0",
-        "2022.1.0",
-        "2022.0.2",
-        "2022.0.1",
-        "2021.4.0",
-        "2021.3.0",
-        "2021.2.0",
-        "2021.1.2",
-    ]
+    available_versions = _get_pkg_versions("intel-oneapi-compilers")
     for v in available_versions:
         version(v)
         # The version of DPC++ must be the same as that of the OneAPI compilers.

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -11,6 +11,8 @@ from llnl.util import filesystem
 from spack import *
 
 def _get_pkg_versions(pkg_name):
+    """Get a list of 'safe' (already checksummed) available versions of a Spack package
+    Equivalent to 'spack versions <pkg_name>' on the command line"""
     pkg_spec = spack.spec.Spec(pkg_name)
     pkg_cls  = spack.repo.path.get_pkg_class(pkg_name)
     pkg      = pkg_cls(pkg_spec)

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -38,8 +38,6 @@ class Dpcpp(Package):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
     maintainers = ["cmacmackin"]
 
-    provides("sycl")
-
     # These are the same as the available versions of OneAPI
     # compilers.
     available_versions = _get_pkg_versions("intel-oneapi-compilers")
@@ -51,6 +49,10 @@ class Dpcpp(Package):
             when="@" + v,
             msg="DPC++ version must match that of OneAPI compilers.",
         )
+
+    # This has to come after the versions (only became an issue after
+    # automatically identifying oneAPI versions, for some reason)
+    provides("sycl")
 
     # This is a dummy package for oneAPI, so conflicts with all other compilers
     # FIXME: Is there a list from somewhere I can import to guarantee

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -14,17 +14,17 @@ def _get_pkg_versions(pkg_name):
     pkg_spec = spack.spec.Spec(pkg_name)
     pkg_cls  = spack.repo.path.get_pkg_class(pkg_name)
     pkg      = pkg_cls(pkg_spec)
-    return sorted([vkey.string for vkey in pkg.versions.keys()])
+    return [vkey.string for vkey in pkg.versions.keys()]
 
 def _restrict_to_version(versions,idx):
     """Return a version constraint that excludes all but versions[idx].
     """
     if idx==0:
-        return versions[1]+":"
+        return ":"+versions[1]
     elif idx==len(versions)-1:
-        return ":"+versions[-2]
+        return versions[-2]+":"
     else:
-        return ":"+versions[idx-1]+","+versions[idx+1]+":"
+        return ":"+versions[idx+1]+","+versions[idx-1]+":"
 
 class Dpcpp(Package):
     """Dummy package that configures the DPC++ implementation of

--- a/packages/dpcpp/package.py
+++ b/packages/dpcpp/package.py
@@ -21,7 +21,9 @@ def _get_pkg_versions(pkg_name):
 
 
 def _restrict_to_version(versions, idx):
-    """Return a version constraint that excludes all but versions[idx]."""
+    """Return a version constraint that excludes all but
+    versions[idx]. Requires versions to be sorted in descending
+    order."""
     if idx == 0:
         return ":" + versions[1]
     elif idx == len(versions) - 1:


### PR DESCRIPTION
Generates Dpcpp versions using the list of available 'intel-oneapi-compilers' versions.
Also rejigs and simplifies`_restrict_to_version`, which was failing for "2023.0.0".