### PR TITLE
Feature/neso particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ spack install neso.nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel
 For more information on using this Spack repo to develop NESO, see the
 [README for that
 repository](https://github.com/ExCALIBUR-NEPTUNE/NESO).
+
+## NESO-Particles
+
+This repository can be used to install NESO-Particles. For example
+
+```
+# With OneAPI/IntelMPI
+spack install neso.neso-particles %oneapi
+# With HipSYCL/Mpich
+spack install neso.neso-particles ^neso.hipsycl ^mpich
+```

--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -13,8 +13,8 @@ class NesoParticles(CMakePackage):
     version("0.1.0", commit="2e1b1aac6f4f9c22b31787cf300fcc2b4914cbe1", preferred=True)
     # 22/08/2022
     version("0.0.1-f54dc8", commit="10a54a410ddd0eb5d1debc702f415dd798eb89ee")
-    version('working', branch='main')
-    version('main', branch='main')
+    version("working", branch="main")
+    version("main", branch="main")
 
     variant("build_tests", default=True, description="Builds the NESO-Particles tests.")
 

--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -11,8 +11,6 @@ class NesoParticles(CMakePackage):
     git = "https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles.git"
 
     version("0.1.0", commit="2e1b1aac6f4f9c22b31787cf300fcc2b4914cbe1", preferred=True)
-    # 22/08/2022
-    version("0.0.1-f54dc8", commit="10a54a410ddd0eb5d1debc702f415dd798eb89ee")
     version("working", branch="main")
     version("main", branch="main")
 

--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -1,0 +1,38 @@
+from spack import *
+import os
+import shutil
+
+
+class NesoParticles(CMakePackage):
+    """NESO-Particles"""
+
+    homepage = "https://excalibur-neptune.github.io/NESO-Particles/"
+
+    git = "https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles.git"
+
+    version("0.1.0", commit="2e1b1aac6f4f9c22b31787cf300fcc2b4914cbe1", preferred=True)
+    # 22/08/2022
+    version("0.0.1-f54dc8", commit="10a54a410ddd0eb5d1debc702f415dd798eb89ee")
+    version('working', branch='main')
+    version('main', branch='main')
+
+    variant("build_tests", default=True, description="Builds the NESO-Particles tests.")
+
+    depends_on("mpi", type=("build", "link", "run"))
+
+    # Non-SYCL dependencies
+    depends_on("hdf5 +mpi +hl", type=("build", "link", "run"))
+    depends_on("cmake@3.21:", type="build")
+    depends_on("googletest@1.10.0: +gmock", type=("build", "link", "run"))
+
+    # Depend on a sycl implementation - with workarounds for intel packaging.
+    depends_on("sycl", type=("build", "link", "run"))
+    depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
+    conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
+    conflicts("^dpcpp", when="%gcc", msg="DPC++ can only be used with Intel oneAPI compilers.")
+
+    def cmake_args(self):
+        args = []
+        if not "+build_tests" in self.spec:
+            args.append("-DENABLE_NESO_PARTICLES_TESTS=off")
+        return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -34,7 +34,7 @@ class Neso(CMakePackage):
     git = "https://github.com/ExCALIBUR-NEPTUNE/NESO"
 
     maintainers = ["jwscook", "will-saunders-ukaea", "cmacmackin"]
-
+    
     version('working', branch='main')
     version('main', branch='main')
 
@@ -58,6 +58,7 @@ class Neso(CMakePackage):
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.74:", type="test")
     depends_on("googletest+gmock", type="link")
+    depends_on("neso-particles")
 
     conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...


### PR DESCRIPTION
This PR:
1. Adds a NESO-Particles (NP) package following the NESO pattern of specifying a SYCL implementation.
2.  Adds a NESO-Particles dependency to NESO.

Testing:
1. Tested NP tests pass with OneAPI/IntelMPI and HipSYCL/MPICH
2. Tested NESO tests pass with OneAPI/IntelMPI and HipSYCL/MPICH (including with the NP interface branches).

Added subsection to README for NP.
Ran black on the NP package.