### PR TITLE
added HipSYCL (OpenSYCL?) version 0.9.4

### DIFF
--- a/packages/hipsycl/package.py
+++ b/packages/hipsycl/package.py
@@ -38,12 +38,17 @@ class Hipsycl(CMakePackage):
     version(
         "0.9.2",
         commit="49fd02499841ae884c61c738610e58c27ab51fdb",
-        submodules=True,
-        preferred=True)
+        submodules=True)
     version(
         "0.9.3",
         commit="51507bad524c33afe8b124804091b10fa25618dc",
         submodules=True)
+    version(
+        "0.9.4",
+        commit="99d9e24d462b35e815e0e59c1b611936c70464ae",
+        submodules=True,
+        preferred=True,
+    )
 
     variant(
         "cuda",
@@ -74,7 +79,7 @@ class Hipsycl(CMakePackage):
     depends_on("cuda@9:10.0", when="@:0.8.0 +cuda")
 
     depends_on("cuda", when="+nvcxx")
-    depends_on("nvhpc", when="+nvcxx", type="run")
+    depends_on("nvhpc@22.9:", when="+nvcxx", type="run")
 
     conflicts(
         "%gcc@:4",


### PR DESCRIPTION
* Added hipsycl (now opensycl) v0.9.4 and made preferred.
A local memory bug with the cuda-nvcxx backend is fixed in hipsycl 0.9.4 and nvhpc 22.9. We use sycl local memory in the upcoming 2D3V evaluation/projection kernels.
* Placed a minimum 22.9 version requirement on nvhpc for the nvcxx backend.

# Tests
* Checked unit/integration tests (on NESO main) passed (omp backend). 