### PR TITLE
Update neso package.py to depend on mpi for build and run

### DIFF
--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -59,6 +59,7 @@ class Neso(CMakePackage):
     depends_on("boost@1.74:", type="test")
     depends_on("googletest+gmock", type="link")
     depends_on("neso-particles")
+    depends_on("mpi", type=("build", "run"))
 
     conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
     # This should really be set in the MKL package itself...


### PR DESCRIPTION
At the moment spack doesn't not register mpi as a build / run dependency of neso. This PR fixes that.