### PR TITLE
Make `nektar` explicitly depend on `zlib`

### DIFF
--- a/packages/nektar/package.py
+++ b/packages/nektar/package.py
@@ -50,6 +50,7 @@ class Nektar(CMakePackage):
     depends_on("cmake@3.2:", type="build", when="+hdf5")
 
     depends_on("blas")
+    depends_on("zlib")
     depends_on("tinyxml", when="+tinyxml")
     depends_on("lapack")
     # Last version supporting C++11


### PR DESCRIPTION
We can't use `zlib-api` because the build system wouldn't recognise `zlib-ng` as a good `zlib` package, moving on to build its own local library.

This fixes https://github.com/ExCALIBUR-NEPTUNE/NESO/issues/222 for me.  Thanks @jwscook for prompting me into looking the zlib dependency.