### PR TITLE
Add nektar@5.5.0-2024-03-14

### DIFF
--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -57,7 +57,7 @@ class Neso(CMakePackage):
     depends_on("sycl", type=("build", "link"))
     depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
     depends_on("fftw-api", type="link")
-    depends_on("nektar@5.2.0-2022-09-03+compflow_solver", type="link")
+    depends_on("nektar@5.5.0-2024-03-14+compflow_solver", type="link")
     depends_on("cmake@3.14:", type="build")
     depends_on("boost@1.74:", type="test")
     depends_on("googletest+gmock", type="link")


### PR DESCRIPTION
Adds a version of nektar compatible with the implicit Hasegawa-Wakatani solver in NESO.
(The 5.5 release is not sufficient, unfortunately).