### PR TITLE
Patch AdaptiveCPP for macos

### DIFF
--- a/packages/adaptivecpp/macos-non-apple-clang-24.02.0.patch
+++ b/packages/adaptivecpp/macos-non-apple-clang-24.02.0.patch
@@ -1,0 +1,15 @@
+--- CMakeLists.txt.orig	2024-06-04 14:39:19
++++ CMakeLists.txt	2024-06-04 14:45:36
+@@ -338,7 +338,11 @@
+ endif()
+ 
+ if(APPLE)
+-  set(DEFAULT_OMP_FLAG "-Xclang -fopenmp")
++  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
++    set(DEFAULT_OMP_FLAG "-Xclang -fopenmp")
++  else()
++    set(DEFAULT_OMP_FLAG "-fopenmp")
++  endif()
+   
+   if(Boost_FIBER_LIBRARY_DEBUG)
+     set(DEFAULT_BOOST_LIBRARIES "${Boost_CONTEXT_LIBRARY_DEBUG} ${Boost_FIBER_LIBRARY_DEBUG} -Wl,-rpath ${Boost_LIBRARY_DIR}")

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -78,6 +78,7 @@ class Adaptivecpp(CMakePackage):
     depends_on("opencl@3.0", when="+opencl")
 
     patch("allow-disable-find-cuda-23.10.0.patch", when="@23.10.0")
+    patch("macos-non-apple-clang-24.02.0.patch", when="@24.02.0")
 
     conflicts(
         "%gcc@:8",


### PR DESCRIPTION
Patches AdaptiveCPP package to use "-fopenmp" instead of "-Xclang -fopenmp" when the compiler is not AppleClang. This lets you brew install llvm (tested with 18.1.6) then do `spack install neso.adaptivecpp` using the brew installed llvm as the compiler and have it work.