### PR TITLE
AdaptiveCpp added nvc++ flag to disable restrict as a keyword.

### DIFF
--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -324,8 +324,10 @@ class Adaptivecpp(CMakePackage):
             # compiler to error. Here we add "--no-restrict-keyword" to the
             # acpp cuda compile and link arguments to disable nvc++ considering
             # "restrict" as a keyword.
-            cuda_config["default-cuda-link-line"] += " --no-restrict-keyword"
-            cuda_config["default-cuda-cxx-flags"] += " --no-restrict-keyword"
+            keys_to_add = ("default-cuda-link-line", "default-cuda-cxx-flags")
+            for kx in keys_to_add:
+                if kx in cuda_config.keys():
+                    cuda_config[kx] += " --no-restrict-keyword"
 
         # Replace the installed config file
         with open(config_file_path, "w") as f:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -75,9 +75,7 @@ class Adaptivecpp(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("boost +filesystem", when="@23.10.0:")
-    depends_on(
-        "boost@1.60.0: +filesystem +fiber +context cxxstd=17", when="@23.10.0:"
-    )
+    depends_on("boost@1.60.0: +filesystem +fiber +context cxxstd=17", when="@23.10.0:")
     depends_on("python@3:")
     # depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda", type=("build", "link", "run"))
@@ -160,9 +158,7 @@ class Adaptivecpp(CMakePackage):
 
             # LLVM directory containing all installed CMake files
             # (e.g.: configs consumed by client projects)
-            llvm_cmake_dirs = filesystem.find(
-                spec["llvm"].prefix, "LLVMExports.cmake"
-            )
+            llvm_cmake_dirs = filesystem.find(spec["llvm"].prefix, "LLVMExports.cmake")
             if len(llvm_cmake_dirs) != 1:
                 raise InstallError(
                     "concretized llvm dependency must provide "
@@ -195,15 +191,11 @@ class Adaptivecpp(CMakePackage):
                     "valid clang++ executable, found invalid: "
                     "{0}".format(llvm_clang_bin)
                 )
-            args.append(
-                "-DCLANG_EXECUTABLE_PATH:String={0}".format(llvm_clang_bin)
-            )
+            args.append("-DCLANG_EXECUTABLE_PATH:String={0}".format(llvm_clang_bin))
 
         if ("+cuda" in spec) or ("+nvcxx" in spec):
             args += [
-                "-DCUDA_TOOLKIT_ROOT_DIR:String={0}".format(
-                    spec["cuda"].prefix
-                ),
+                "-DCUDA_TOOLKIT_ROOT_DIR:String={0}".format(spec["cuda"].prefix),
                 "-DWITH_CUDA_BACKEND:Bool=TRUE",
             ]
         else:
@@ -325,6 +317,15 @@ class Adaptivecpp(CMakePackage):
             default_targets = "default-targets"
             if default_targets in config.keys():
                 config[default_targets] = "omp.library-only"
+
+        if ("+nvcxx" in self.spec) and (cuda_config is not None):
+            # By default nvc++ considers "restrict" to be a keyword. Nektar++
+            # has methods/functions called restrict and these cause the nvc++
+            # compiler to error. Here we add "--no-restrict-keyword" to the
+            # acpp cuda compile and link arguments to disable nvc++ considering
+            # "restrict" as a keyword.
+            cuda_config["default-cuda-link-line"] += " --no-restrict-keyword"
+            cuda_config["default-cuda-cxx-flags"] += " --no-restrict-keyword"
 
         # Replace the installed config file
         with open(config_file_path, "w") as f:


### PR DESCRIPTION
By default nvc++ considers "restrict" as a keyword. Nektar++ uses functions/methods called restrict which cause a compiler error. This update adds "--no-restrict-keyword" to the compiler flags when nvc++ is the compiler.

Applied black formatting.