### PR TITLE
Create libonly variant for NESO

### DIFF
--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -41,7 +41,7 @@ class NesoParticles(CMakePackage):
     def cmake_args(self):
         args = []
         if not "+build_tests" in self.spec:
-            args.append("-DENABLE_NESO_PARTICLES_TESTS=off")
+            args.append("-DNESO_PARTICLES_ENABLE_TESTS=off")
         if "+nvcxx" in self.spec:
             args.append("-DNESO_PARTICLES_DEVICE_TYPE=GPU")
             args.append("-DHIPSYCL_TARGETS=cuda-nvcxx")

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -170,7 +170,7 @@ class Neso(CMakePackage):
             args.append("-DSYCL_DEVICE_FILTER=GPU")
 
         if "+libonly" in self.spec:
-            args.append("-DENABLE_NESO_SOLVERS=OFF")
-            args.append("-DENABLE_NESO_TESTS=OFF")
+            args.append("-DNESO_BUILD_SOLVERS=OFF")
+            args.append("-DNESO_BUILD_TESTS=OFF")
 
         return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -83,6 +83,8 @@ class Neso(CMakePackage):
     )
     variant("nvcxx", default=False, description="Enable compilation using nvcxx")
 
+    variant("libonly", default=False, description="Only compiles the library elements and not the solvers or tests")
+
     # Some SYCL packages require a specific run-time environment to be set
     depends_on("sycl", type=("build", "link"))
     depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
@@ -145,5 +147,9 @@ class Neso(CMakePackage):
         if "+nvcxx" in self.spec:
             args.append("-DHIPSYCL_TARGETS=cuda-nvcxx")
             args.append("-DSYCL_DEVICE_FILTER=GPU")
+
+        if "+libonly" in self.spec:
+            args.append("-DENABLE_NESO_SOLVERS=OFF")
+            args.append("-DENABLE_NESO_TESTS=OFF")
 
         return args


### PR DESCRIPTION
Faster overall build for dependencies i.e. NESO-Tokamak if NESO does not build built-in solvers.
Also correcting flag in NESO-Particles package