### PR TITLE
Feature/acpp variants

### DIFF
--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -408,7 +408,7 @@ class Adaptivecpp(CMakePackage):
         if self.get_cuda_arch() != "none":
             if self.compilation_workflow == "cuda-llvm":
                 cuda_arch = ":sm_" + self.get_cuda_arch()
-            elif self.get_compilation_workflow() == "cuda-nvcxx":
+            elif self.compilation_workflow == "cuda-nvcxx":
                 cuda_arch = ":cc" + self.get_cuda_arch()
 
         # Populate the default-target in the config file with the compilation

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -198,7 +198,8 @@ class Adaptivecpp(CMakePackage):
 
     # Spack doesn't seem to populate the spec with the default multivalued
     # variant information.
-    def get_cuda_arch(self):
+    @property
+    def cuda_arch(self):
         if "cuda_arch" in self.spec.variants:
             return self.spec.variants["cuda_arch"].value
         else:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -324,8 +324,10 @@ class Adaptivecpp(CMakePackage):
             # compiler to error. Here we add "--no-restrict-keyword" to the
             # acpp cuda compile and link arguments to disable nvc++ considering
             # "restrict" as a keyword.
-            cuda_config["default-cuda-link-line"] += " --no-restrict-keyword"
-            cuda_config["default-cuda-cxx-flags"] += " --no-restrict-keyword"
+            keys_to_add = ("default-cuda-link-line", "default-cuda-cxx-flags")
+            for kx in keys_to_add:
+                if kx in cuda_config.keys():
+                    cuda_config[kx] += " --no-restrict-keyword"
 
         # Replace the installed config file
         with open(config_file_path, "w") as f:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -210,7 +210,7 @@ class Adaptivecpp(CMakePackage):
         # As spack doesn't seem to populate mutlivalued variants with default
         # values and check conflicts properly we check here that the cuda arch
         # is specified for cuda-llvm.
-        if self.get_compilation_workflow() == "cuda-llvm":
+        if self.compilation_workflow == "cuda-llvm":
             if self.default_cuda_arch == self.get_cuda_arch():
                 raise spack.error.SpackError(
                     "cuda-llvm requires cuda_arch to be set"

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -52,17 +52,17 @@ class Adaptivecpp(CMakePackage):
         submodules=True,
     )
 
-    default_compilationflow = "omp-library-only"
+    default_compilationflow = "omp_library_only"
     variant(
         "compilationflow",
         default=default_compilationflow,
         values=(
             default_compilationflow,
-            "omp-accelerated",
-            "cuda-llvm",
-            "cuda-nvcxx",
+            "omp_accelerated",
+            "cuda_llvm",
+            "cuda_nvcxx",
         ),
-        description="Specify the default compilation workflow which this install will use for all translation units. Setting this variant will automatically select other variants as needed. For cuda compilation flows the CUDA architecture should be set with, e.g. 'cuda_arch=80'. The cuda-llvm flow requires that cuda_arch is set.",
+        description="Specify the default compilation workflow which this install will use for all translation units. Setting this variant will automatically select other variants as needed. For cuda compilation flows the CUDA architecture should be set with, e.g. 'cuda_arch=80'. The cuda_llvm flow requires that cuda_arch is set.",
         multi=False,
     )
 
@@ -74,10 +74,10 @@ class Adaptivecpp(CMakePackage):
         "cuda_arch",
         default=default_cuda_arch,
         values=cuda_arch_values,
-        description="Specify the CUDA architecture to use. Required, i.e. not 'none', for cuda-llvm compilation flow.",
+        description="Specify the CUDA architecture to use. Required, i.e. not 'none', for cuda_llvm compilation flow.",
         multi=False,
     )
-    conflicts("cuda_arch=none", when="compilationflow=cuda-llvm")
+    conflicts("cuda_arch=none", when="compilationflow=cuda_llvm")
 
     variant(
         "cuda",
@@ -87,10 +87,10 @@ class Adaptivecpp(CMakePackage):
     variant(
         "cuda",
         default=True,
-        when="compilationflow=cuda-llvm",
+        when="compilationflow=cuda_llvm",
         description="Enable CUDA backend for SYCL kernels using llvm+cuda",
     )
-    conflicts("~cuda", when="compilationflow=cuda-llvm")
+    conflicts("~cuda", when="compilationflow=cuda_llvm")
     variant(
         "nvcxx",
         default=False,
@@ -99,22 +99,15 @@ class Adaptivecpp(CMakePackage):
     variant(
         "nvcxx",
         default=True,
-        when="compilationflow=cuda-nvcxx",
+        when="compilationflow=cuda_nvcxx",
         description="Enable CUDA backend for SYCL kernels using nvcxx",
     )
-    conflicts("~nvcxx", when="compilationflow=cuda-nvcxx")
+    conflicts("~nvcxx", when="compilationflow=cuda_nvcxx")
     variant(
         "omp_llvm",
         default=False,
         description="Enable accelerated OMP backend for SYCL kernels using LLVM",
     )
-    variant(
-        "omp_llvm",
-        default=True,
-        when="compilationflow=omp-accelerated",
-        description="Enable accelerated OMP backend for SYCL kernels using LLVM",
-    )
-    conflicts("~omp_llvm", when="compilationflow=omp-accelerated")
     variant(
         "opencl",
         default=False,
@@ -209,11 +202,11 @@ class Adaptivecpp(CMakePackage):
 
         # As spack doesn't seem to populate mutlivalued variants with default
         # values and check conflicts properly we check here that the cuda arch
-        # is specified for cuda-llvm.
-        if self.compilation_workflow == "cuda-llvm":
+        # is specified for cuda_llvm.
+        if self.compilation_workflow == "cuda_llvm":
             if self.default_cuda_arch == self.cuda_arch:
                 raise spack.error.SpackError(
-                    "cuda-llvm requires cuda_arch to be set"
+                    "cuda_llvm requires cuda_arch to be set"
                 )
 
         spec = self.spec
@@ -406,18 +399,18 @@ class Adaptivecpp(CMakePackage):
 
         cuda_arch = ""
         if self.cuda_arch != "none":
-            if self.compilation_workflow == "cuda-llvm":
+            if self.compilation_workflow == "cuda_llvm":
                 cuda_arch = ":sm_" + self.cuda_arch
-            elif self.compilation_workflow == "cuda-nvcxx":
+            elif self.compilation_workflow == "cuda_nvcxx":
                 cuda_arch = ":cc" + self.cuda_arch
 
         # Populate the default-target in the config file with the compilation
         # flow which was chosen.
         map_variant_to_target = {
-            "omp-library-only": "omp.library-only",
-            "omp-accelerated": "omp.accelerated",
-            "cuda-llvm": "cuda" + cuda_arch,
-            "cuda-nvcxx": "cuda-nvcxx" + cuda_arch,
+            "omp_library_only": "omp.library-only",
+            "omp_accelerated": "omp.accelerated",
+            "cuda_llvm": "cuda" + cuda_arch,
+            "cuda_nvcxx": "cuda_nvcxx" + cuda_arch,
         }
         default_targets = "default-targets"
         if default_targets in config:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -211,7 +211,7 @@ class Adaptivecpp(CMakePackage):
         # values and check conflicts properly we check here that the cuda arch
         # is specified for cuda-llvm.
         if self.compilation_workflow == "cuda-llvm":
-            if self.default_cuda_arch == self.get_cuda_arch():
+            if self.default_cuda_arch == self.cuda_arch:
                 raise spack.error.SpackError(
                     "cuda-llvm requires cuda_arch to be set"
                 )

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -416,7 +416,7 @@ class Adaptivecpp(CMakePackage):
             "omplibraryonly": "omp.library-only",
             "ompaccelerated": "omp.accelerated",
             "cudallvm": "cuda" + cuda_arch,
-            "cudanvcxx": "cudanvcxx" + cuda_arch,
+            "cudanvcxx": "cuda-nvcxx" + cuda_arch,
         }
         default_targets = "default-targets"
         if default_targets in config:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -75,9 +75,7 @@ class Adaptivecpp(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("boost +filesystem", when="@23.10.0:")
-    depends_on(
-        "boost@1.60.0: +filesystem +fiber +context cxxstd=17", when="@23.10.0:"
-    )
+    depends_on("boost@1.60.0: +filesystem +fiber +context cxxstd=17", when="@23.10.0:")
     depends_on("python@3:")
     # depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda", type=("build", "link", "run"))
@@ -160,9 +158,7 @@ class Adaptivecpp(CMakePackage):
 
             # LLVM directory containing all installed CMake files
             # (e.g.: configs consumed by client projects)
-            llvm_cmake_dirs = filesystem.find(
-                spec["llvm"].prefix, "LLVMExports.cmake"
-            )
+            llvm_cmake_dirs = filesystem.find(spec["llvm"].prefix, "LLVMExports.cmake")
             if len(llvm_cmake_dirs) != 1:
                 raise InstallError(
                     "concretized llvm dependency must provide "
@@ -195,15 +191,11 @@ class Adaptivecpp(CMakePackage):
                     "valid clang++ executable, found invalid: "
                     "{0}".format(llvm_clang_bin)
                 )
-            args.append(
-                "-DCLANG_EXECUTABLE_PATH:String={0}".format(llvm_clang_bin)
-            )
+            args.append("-DCLANG_EXECUTABLE_PATH:String={0}".format(llvm_clang_bin))
 
         if ("+cuda" in spec) or ("+nvcxx" in spec):
             args += [
-                "-DCUDA_TOOLKIT_ROOT_DIR:String={0}".format(
-                    spec["cuda"].prefix
-                ),
+                "-DCUDA_TOOLKIT_ROOT_DIR:String={0}".format(spec["cuda"].prefix),
                 "-DWITH_CUDA_BACKEND:Bool=TRUE",
             ]
         else:
@@ -325,6 +317,15 @@ class Adaptivecpp(CMakePackage):
             default_targets = "default-targets"
             if default_targets in config.keys():
                 config[default_targets] = "omp.library-only"
+
+        if ("+nvcxx" in self.spec) and (cuda_config is not None):
+            # By default nvc++ considers "restrict" to be a keyword. Nektar++
+            # has methods/functions called restrict and these cause the nvc++
+            # compiler to error. Here we add "--no-restrict-keyword" to the
+            # acpp cuda compile and link arguments to disable nvc++ considering
+            # "restrict" as a keyword.
+            cuda_config["default-cuda-link-line"] += " --no-restrict-keyword"
+            cuda_config["default-cuda-cxx-flags"] += " --no-restrict-keyword"
 
         # Replace the installed config file
         with open(config_file_path, "w") as f:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -422,7 +422,7 @@ class Adaptivecpp(CMakePackage):
         default_targets = "default-targets"
         if default_targets in config:
             config[default_targets] = map_variant_to_target[
-                self.get_compilation_workflow()
+                self.compilation_workflow
             ]
 
         # Replace the installed config file

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -409,7 +409,7 @@ class Adaptivecpp(CMakePackage):
             if self.compilation_workflow == "cuda-llvm":
                 cuda_arch = ":sm_" + self.cuda_arch
             elif self.compilation_workflow == "cuda-nvcxx":
-                cuda_arch = ":cc" + self.get_cuda_arch()
+                cuda_arch = ":cc" + self.cuda_arch
 
         # Populate the default-target in the config file with the compilation
         # flow which was chosen.

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -189,7 +189,8 @@ class Adaptivecpp(CMakePackage):
 
     # Spack doesn't seem to populate the spec with the default multivalued
     # variant information.
-    def get_compilation_workflow(self):
+    @property
+    def compilation_workflow(self):
         if "compilationflow" in self.spec.variants:
             return self.spec.variants["compilationflow"].value
         else:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -420,7 +420,7 @@ class Adaptivecpp(CMakePackage):
             "cuda-nvcxx": "cuda-nvcxx" + cuda_arch,
         }
         default_targets = "default-targets"
-        if default_targets in config.keys():
+        if default_targets in config:
             config[default_targets] = map_variant_to_target[
                 self.get_compilation_workflow()
             ]

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -406,7 +406,7 @@ class Adaptivecpp(CMakePackage):
 
         cuda_arch = ""
         if self.get_cuda_arch() != "none":
-            if self.get_compilation_workflow() == "cuda-llvm":
+            if self.compilation_workflow == "cuda-llvm":
                 cuda_arch = ":sm_" + self.get_cuda_arch()
             elif self.get_compilation_workflow() == "cuda-nvcxx":
                 cuda_arch = ":cc" + self.get_cuda_arch()

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -52,17 +52,17 @@ class Adaptivecpp(CMakePackage):
         submodules=True,
     )
 
-    default_compilationflow = "omp_library_only"
+    default_compilationflow = "omplibraryonly"
     variant(
         "compilationflow",
         default=default_compilationflow,
         values=(
             default_compilationflow,
-            "omp_accelerated",
-            "cuda_llvm",
-            "cuda_nvcxx",
+            "ompaccelerated",
+            "cudallvm",
+            "cudanvcxx",
         ),
-        description="Specify the default compilation workflow which this install will use for all translation units. Setting this variant will automatically select other variants as needed. For cuda compilation flows the CUDA architecture should be set with, e.g. 'cuda_arch=80'. The cuda_llvm flow requires that cuda_arch is set.",
+        description="Specify the default compilation workflow which this install will use for all translation units. Setting this variant will automatically select other variants as needed. For cuda compilation flows the CUDA architecture should be set with, e.g. 'cuda_arch=80'. The cudallvm flow requires that cuda_arch is set.",
         multi=False,
     )
 
@@ -74,10 +74,10 @@ class Adaptivecpp(CMakePackage):
         "cuda_arch",
         default=default_cuda_arch,
         values=cuda_arch_values,
-        description="Specify the CUDA architecture to use. Required, i.e. not 'none', for cuda_llvm compilation flow.",
+        description="Specify the CUDA architecture to use. Required, i.e. not 'none', for cudallvm compilation flow.",
         multi=False,
     )
-    conflicts("cuda_arch=none", when="compilationflow=cuda_llvm")
+    conflicts("cuda_arch=none", when="compilationflow=cudallvm")
 
     variant(
         "cuda",
@@ -87,10 +87,10 @@ class Adaptivecpp(CMakePackage):
     variant(
         "cuda",
         default=True,
-        when="compilationflow=cuda_llvm",
+        when="compilationflow=cudallvm",
         description="Enable CUDA backend for SYCL kernels using llvm+cuda",
     )
-    conflicts("~cuda", when="compilationflow=cuda_llvm")
+    conflicts("~cuda", when="compilationflow=cudallvm")
     variant(
         "nvcxx",
         default=False,
@@ -99,10 +99,10 @@ class Adaptivecpp(CMakePackage):
     variant(
         "nvcxx",
         default=True,
-        when="compilationflow=cuda_nvcxx",
+        when="compilationflow=cudanvcxx",
         description="Enable CUDA backend for SYCL kernels using nvcxx",
     )
-    conflicts("~nvcxx", when="compilationflow=cuda_nvcxx")
+    conflicts("~nvcxx", when="compilationflow=cudanvcxx")
     variant(
         "omp_llvm",
         default=False,
@@ -111,7 +111,7 @@ class Adaptivecpp(CMakePackage):
     variant(
         "omp_llvm",
         default=True,
-        when="compilationflow=omp_accelerated",
+        when="compilationflow=ompaccelerated",
         description="Enable accelerated OMP backend for SYCL kernels using LLVM",
     )
     variant(
@@ -208,11 +208,11 @@ class Adaptivecpp(CMakePackage):
 
         # As spack doesn't seem to populate mutlivalued variants with default
         # values and check conflicts properly we check here that the cuda arch
-        # is specified for cuda_llvm.
-        if self.compilation_workflow == "cuda_llvm":
+        # is specified for cudallvm.
+        if self.compilation_workflow == "cudallvm":
             if self.default_cuda_arch == self.cuda_arch:
                 raise spack.error.SpackError(
-                    "cuda_llvm requires cuda_arch to be set"
+                    "cudallvm requires cuda_arch to be set"
                 )
 
         spec = self.spec
@@ -405,18 +405,18 @@ class Adaptivecpp(CMakePackage):
 
         cuda_arch = ""
         if self.cuda_arch != "none":
-            if self.compilation_workflow == "cuda_llvm":
+            if self.compilation_workflow == "cudallvm":
                 cuda_arch = ":sm_" + self.cuda_arch
-            elif self.compilation_workflow == "cuda_nvcxx":
+            elif self.compilation_workflow == "cudanvcxx":
                 cuda_arch = ":cc" + self.cuda_arch
 
         # Populate the default-target in the config file with the compilation
         # flow which was chosen.
         map_variant_to_target = {
-            "omp_library_only": "omp.library-only",
-            "omp_accelerated": "omp.accelerated",
-            "cuda_llvm": "cuda" + cuda_arch,
-            "cuda_nvcxx": "cuda_nvcxx" + cuda_arch,
+            "omplibraryonly": "omp.library-only",
+            "ompaccelerated": "omp.accelerated",
+            "cudallvm": "cuda" + cuda_arch,
+            "cudanvcxx": "cudanvcxx" + cuda_arch,
         }
         default_targets = "default-targets"
         if default_targets in config:

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -407,7 +407,7 @@ class Adaptivecpp(CMakePackage):
         cuda_arch = ""
         if self.cuda_arch != "none":
             if self.compilation_workflow == "cuda-llvm":
-                cuda_arch = ":sm_" + self.get_cuda_arch()
+                cuda_arch = ":sm_" + self.cuda_arch
             elif self.compilation_workflow == "cuda-nvcxx":
                 cuda_arch = ":cc" + self.get_cuda_arch()
 

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -405,7 +405,7 @@ class Adaptivecpp(CMakePackage):
                     cuda_config[kx] += " --no-restrict-keyword"
 
         cuda_arch = ""
-        if self.get_cuda_arch() != "none":
+        if self.cuda_arch != "none":
             if self.compilation_workflow == "cuda-llvm":
                 cuda_arch = ":sm_" + self.get_cuda_arch()
             elif self.compilation_workflow == "cuda-nvcxx":

--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -109,6 +109,12 @@ class Adaptivecpp(CMakePackage):
         description="Enable accelerated OMP backend for SYCL kernels using LLVM",
     )
     variant(
+        "omp_llvm",
+        default=True,
+        when="compilationflow=omp_accelerated",
+        description="Enable accelerated OMP backend for SYCL kernels using LLVM",
+    )
+    variant(
         "opencl",
         default=False,
         description="Enable OpenCL backend.",

--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -34,7 +34,7 @@ class NesoParticles(CMakePackage):
     variant(
         "nvcxx",
         default=False,
-        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda-nvcxx' instead. Builds with CUDA via AdaptiveCpp and nvc++.",
+        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda_nvcxx' instead. Builds with CUDA via AdaptiveCpp and nvc++.",
     )
     variant(
         "petsc",
@@ -56,7 +56,7 @@ class NesoParticles(CMakePackage):
     depends_on("sycl", type=("build", "link", "run"))
 
     # backwards compatibility and workarounds for intel packaging
-    depends_on("neso.adaptivecpp compilationflow=cuda-nvcxx", when="+nvcxx")
+    depends_on("neso.adaptivecpp compilationflow=cuda_nvcxx", when="+nvcxx")
     depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
     conflicts(
         "^dpcpp",

--- a/packages/neso-particles/package.py
+++ b/packages/neso-particles/package.py
@@ -34,7 +34,7 @@ class NesoParticles(CMakePackage):
     variant(
         "nvcxx",
         default=False,
-        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda_nvcxx' instead. Builds with CUDA via AdaptiveCpp and nvc++.",
+        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cudanvcxx' instead. Builds with CUDA via AdaptiveCpp and nvc++.",
     )
     variant(
         "petsc",
@@ -56,7 +56,7 @@ class NesoParticles(CMakePackage):
     depends_on("sycl", type=("build", "link", "run"))
 
     # backwards compatibility and workarounds for intel packaging
-    depends_on("neso.adaptivecpp compilationflow=cuda_nvcxx", when="+nvcxx")
+    depends_on("neso.adaptivecpp compilationflow=cudanvcxx", when="+nvcxx")
     depends_on("intel-oneapi-dpl", when="^dpcpp", type="link")
     conflicts(
         "^dpcpp",

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -93,7 +93,7 @@ class Neso(CMakePackage):
     variant(
         "nvcxx",
         default=False,
-        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda-nvcxx' instead. Enable compilation using nvcxx",
+        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda_nvcxx' instead. Enable compilation using nvcxx",
     )
     variant(
         "cwipi",
@@ -120,7 +120,7 @@ class Neso(CMakePackage):
     depends_on("mpi", type=("build", "run"))
 
     # backwards compatibility and workarounds for intel packaging
-    depends_on("neso.adaptivecpp compilationflow=cuda-nvcxx", when="+nvcxx")
+    depends_on("neso.adaptivecpp compilationflow=cuda_nvcxx", when="+nvcxx")
 
     # Nektar++ dependency
     nektar_base_spec = "nektar@5.3.0-2022-09-03:+compflow_solver"

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -73,15 +73,28 @@ class Neso(CMakePackage):
     variant(
         "sanitizer",
         description="The sanitizers to compile with",
-        values=("none", "address", "leak", "thread", "memory", "undefined_behaviour"),
+        values=(
+            "none",
+            "address",
+            "leak",
+            "thread",
+            "memory",
+            "undefined_behaviour",
+        ),
         default="none",
         multi=True,
         validator=_validate_sanitizer_variant,
     )
     variant(
-        "coverage", default=False, description="Enable coverage reporting for GCC/Clang"
+        "coverage",
+        default=False,
+        description="Enable coverage reporting for GCC/Clang",
     )
-    variant("nvcxx", default=False, description="Enable compilation using nvcxx")
+    variant(
+        "nvcxx",
+        default=False,
+        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda-nvcxx' instead. Enable compilation using nvcxx",
+    )
 
     # Some SYCL packages require a specific run-time environment to be set
     depends_on("sycl", type=("build", "link"))
@@ -94,15 +107,26 @@ class Neso(CMakePackage):
     depends_on("neso-particles")
     depends_on("mpi", type=("build", "run"))
 
+    # backwards compatibility and workarounds for intel packaging
+    depends_on("neso.adaptivecpp compilationflow=cuda-nvcxx", when="+nvcxx")
     conflicts("%dpcpp", msg="Use oneapi compilers instead of dpcpp driver.")
-    conflicts("^dpcpp", when="%gcc", msg="DPC++ can only be used with Intel oneAPI compilers.")
-    conflicts("+nvcxx", when="%oneapi", msg="Nvidia compilation option can only be used with gcc compilers")
+    conflicts(
+        "^dpcpp",
+        when="%gcc",
+        msg="DPC++ can only be used with Intel oneAPI compilers.",
+    )
+    conflicts(
+        "+nvcxx",
+        when="%oneapi",
+        msg="Nvidia compilation option can only be used with gcc compilers",
+    )
     # Should only use MKL with the same release of OneAPI
     # compilers. Ideally this would have been set in the MKL package
     # itself.
     for idx, v in enumerate(AVAILABLE_ONEAPI_VERSIONS):
         conflicts(
-            "^intel-oneapi-mkl@" + _restrict_to_version(AVAILABLE_ONEAPI_VERSIONS, idx),
+            "^intel-oneapi-mkl@"
+            + _restrict_to_version(AVAILABLE_ONEAPI_VERSIONS, idx),
             when="%oneapi@" + v,
             msg="OneAPI compilers and MKL must be from the same release.",
         )
@@ -126,27 +150,9 @@ class Neso(CMakePackage):
         if "intel" in self.spec["mpi"].name:
             if "I_MPI_FABRICS" not in environ:
                 warn(
-                    "The intel mpi specific environment variable, I_MPI_FABRICS, has not been set and an intel-MPI build will fail. If you are developing on an unmanaged-HPC machine, i.e. locally on your workstation, a sensible default `export I_MPI_FABRICS=shm`. Information can be found on the intel documentation pages https://tinyurl.com/33w8x8wp.",
+                    "The intel mpi specific environment variable, I_MPI_FABRICS, has not been set. This environment variable should be set on certain platforms, e.g. Docker, where `export I_MPI_FABRICS=shm` may prevent issues. Information can be found on the intel documentation pages https://tinyurl.com/33w8x8wp.",
                     UserWarning,
                     stacklevel=1,
                 )
-        for depspec in self.spec.dependencies():
-            for dep in depspec.dependents():
-                if "sycl" in dep:
-                    if "SYCL_DEVICE_FILTER" not in environ:
-                        warn(
-                            "The environment variable SYCL_DEVICE_FILTER is not set and the code may not run as intended in this environment. A sensible default for running on the cpu is `export SYCL_DEVICE_FILTER=host`. For more information please see e.g. https://tinyurl.com/y37672as.",
-                            UserWarning,
-                            stacklevel=1,
-                        )
-
-                    break
-
-        if "+nvcxx" in self.spec:
-            if "^hipsycl" in self.spec:
-                args.append("-DHIPSYCL_TARGETS=cuda-nvcxx")
-            elif "^adaptivecpp" in self.spec:
-                args.append("-DACPP_TARGETS=cuda-nvcxx")
-            args.append("-DSYCL_DEVICE_FILTER=GPU")
 
         return args

--- a/packages/neso/package.py
+++ b/packages/neso/package.py
@@ -93,7 +93,7 @@ class Neso(CMakePackage):
     variant(
         "nvcxx",
         default=False,
-        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cuda_nvcxx' instead. Enable compilation using nvcxx",
+        description="Deprecated, please use '^neso.adaptivecpp compilationflow=cudanvcxx' instead. Enable compilation using nvcxx",
     )
     variant(
         "cwipi",
@@ -120,7 +120,7 @@ class Neso(CMakePackage):
     depends_on("mpi", type=("build", "run"))
 
     # backwards compatibility and workarounds for intel packaging
-    depends_on("neso.adaptivecpp compilationflow=cuda_nvcxx", when="+nvcxx")
+    depends_on("neso.adaptivecpp compilationflow=cudanvcxx", when="+nvcxx")
 
     # Nektar++ dependency
     nektar_base_spec = "nektar@5.3.0-2022-09-03:+compflow_solver"


### PR DESCRIPTION
This PR is an attempt to resolve the issue that in the NESO stack we do not robustly specify the SYCL compilation backend for all of the nodes in the dependency tree when using AdaptiveCpp. Currently when we do `^adaptivecpp` in NESO-Tokamak we essentially rely on the default backend being the omp.library-only backend for all of the dependencies. For some elements we had `+nvcxx` variants that use the cuda-nvcxx backend of acpp for compilation. 

What this PR does is move the specification of how acpp should compile objects into the acpp package. The user specifies which one of acpp's "compilation flows" to use when acpp is installed. This compilation flow is then used for all objects compiled by that install of acpp. 

For example NESO-Tokamak (NT) or Reactions can write a spec like
```
spack install neso ^neso.adaptivecpp compilationflow=omp-library-only
```
to explicitly use the default omp library only backend. If say NT or NESO be built with a different flow then the flow can be swapped out at the most downstream level, e.g. in a NT  spack.yaml and that will ensure all the libraries in the dependency tree are compiled with the same workflow. e.g.

```
spack install neso ^neso.adaptivecpp compilationflow=cuda-nvcxx
```
for cuda-nvcxx. Or

```
spack install neso ^neso.adaptivecpp compilationflow=cuda-llvm cuda_arch=89
```
for cuda compiled via llvm. Note that the cuda llvm flow requires a cuda arch to be specified. When new compilation flows are added to acpp (e.g. https://github.com/ExCALIBUR-NEPTUNE/NESO-Spack/pull/54) then changing the specified compilationflow should ensure all the dependencies are compiled against the correct backend.

This update also means that the spack packages for NESO, NP do not need nvcxx specific variants (I kept them for backwards compatibility but they just specify `^neso.adaptivecpp compilationflow=cuda-nvcxx`. 

Tagging relevant people:
@oparry-ukaea @JamesEdgeley @gadgil48 @SMijin @cmacmackin 




