### PR TITLE
Adds version for adaptivecpp 25.10.0.

### DIFF
--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -52,6 +52,11 @@ class Adaptivecpp(CMakePackage):
     provides("sycl")
 
     version(
+        "25.10.0",
+        commit="9f842c701a599107cc6d117d3539f971036363a1",
+        submodules=True,
+    )
+    version(
         "25.02.0",
         commit="883b0e11b11fc59f37fa69e40c18446fcad03c50",
         submodules=True,


### PR DESCRIPTION
Seems to build NP ok.

TODO:
* boost is now only required to build the tests.
* apply the malloc patch?