### PR TITLE
NESO-RNG-Toolkit: if curand and onemkl are not specified

### DIFF
--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -84,7 +84,7 @@ class NesoRngToolkit(CMakePackage):
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
 
         else:
-            args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
 
         return args

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -79,8 +79,12 @@ class NesoRngToolkit(CMakePackage):
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_ONEMKL=ON")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
 
-        if "+curand" in self.spec:
+        elif "+curand" in self.spec:
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=ON")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
+
+        else:
+            args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
 
         return args


### PR DESCRIPTION
NESO-RNG-Toolkit: if curand and onemkl are not specified disable searching from them (otherwise cmake finds system installs of cuda and fails).