### PR TITLE
Initial attempt to add hiprand and correct adaptivecpp package.

### DIFF
--- a/packages/adaptivecpp/package.py
+++ b/packages/adaptivecpp/package.py
@@ -273,10 +273,21 @@ class Adaptivecpp(CMakePackage):
     # Dependencies for ROCm/HIP support.
     depends_on("rocm-core", when="compilationflow=hip")
     depends_on("rocm-core", when="compilationflow=generic +rocm")
-    depends_on("rocm-device-libs", when="compilationflow=hip")
-    depends_on("rocm-device-libs", when="compilationflow=generic +rocm")
-    depends_on("hip", when="compilationflow=hip")
-    depends_on("hip", when="compilationflow=generic +rocm")
+
+    # We need the device libs either from llvm-amdgpu or rocm-device-libs.
+    depends_on("llvm-amdgpu", when="compilationflow=hip")
+    depends_on("llvm-amdgpu", when="compilationflow=generic +rocm")
+    depends_on(
+        "rocm-device-libs",
+        when="compilationflow=hip ^llvm-amdgpu~rocm-device-libs",
+    )
+    depends_on(
+        "rocm-device-libs",
+        when="compilationflow=generic +rocm ^llvm-amdgpu~rocm-device-libs",
+    )
+
+    depends_on("hip +rocm", when="compilationflow=hip")
+    depends_on("hip +rocm", when="compilationflow=generic +rocm")
 
     patch("allow-disable-find-cuda-23.10.0.patch", when="@23.10.0")
     patch("macos-non-apple-clang-24.02.0.patch", when="@24.02.0")
@@ -467,9 +478,17 @@ class Adaptivecpp(CMakePackage):
         # These should be the compilation flows that involve the amd ROCm stack
         if self.compilation_workflow == "hip" or "+rocm" in self.spec:
             rocm_core_prefix = spec["rocm-core"].prefix
-            rocm_device_libs_prefix = (
-                spec["rocm-device-libs"].prefix + "/amdgcn/bitcode"
-            )
+
+            rocm_device_libs_prefix = None
+            if self.spec.satisfies("^rocm-device-libs"):
+                rocm_device_libs_prefix = spec[
+                    "rocm-device-libs"
+                ].prefix.amdgcn.bitcode
+            else:
+                rocm_device_libs_prefix = spec[
+                    "llvm-amdgpu"
+                ].prefix.amdgcn.bitcode
+
             args += [
                 "-DROCM_PATH=" + rocm_core_prefix,
                 "-DROCM_DEVICE_LIBS_PATH=" + rocm_device_libs_prefix,

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -45,6 +45,7 @@ class NesoRngToolkit(CMakePackage):
     )
     conflicts("+onemkl", when="+curand")
     conflicts("+onemkl", when="+hiprand")
+    conflicts("+onemkl", when="^adaptivecpp")
     conflicts("+curand", when="+hiprand")
 
     # Depend on a sycl implementation.

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -105,9 +105,13 @@ class NesoRngToolkit(CMakePackage):
             "^adaptivecpp compilationflow=omplibraryonly" in self.spec
             or "^adaptivecpp compilationflow=ompaccelerated" in self.spec
         )
-        use_onemkl = ("+onemkl" in self.spec) or (
-            platformsearch and ("^dpcpp" in self.spec)
+
+        use_onemkl = (
+            ("+onemkl" in self.spec)
+            or platformsearch
+            and ("^dpcpp" in self.spec)
         )
+
         use_curand = ("+curand" in self.spec) or (
             platformsearch
             and (

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -20,7 +20,6 @@ class NesoRngToolkit(CMakePackage):
 
     version("working", branch="main")
     version("main", branch="main", preferred=True)
-    version("test", commit="582db42f3f8fdfdee9e0b61cc937b07d65415968")
     version("0.1.0", commit="9fe3d25bd72bab535dba51541a36f1dc14404075")
 
     variant(

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -19,7 +19,9 @@ class NesoRngToolkit(CMakePackage):
     git = "https://github.com/ExCALIBUR-NEPTUNE/NESO-RNG-Toolkit.git"
 
     version("working", branch="main")
-    version("main", branch="main")
+    version("main", branch="main", preferred=True)
+    version("test", commit="582db42f3f8fdfdee9e0b61cc937b07d65415968")
+    version("0.1.0", commit="9fe3d25bd72bab535dba51541a36f1dc14404075")
 
     variant(
         "onemkl",
@@ -31,7 +33,14 @@ class NesoRngToolkit(CMakePackage):
         default=False,
         description="Enables the cuRAND RNG as a required platform. Disables other platforms.",
     )
+    variant(
+        "hiprand",
+        default=False,
+        description="Enables the hipRAND RNG as a required platform. Disables other platforms.",
+    )
     conflicts("+onemkl", when="+curand")
+    conflicts("+onemkl", when="+hiprand")
+    conflicts("+curand", when="+hiprand")
 
     # Depend on a sycl implementation.
     depends_on("c")
@@ -39,6 +48,7 @@ class NesoRngToolkit(CMakePackage):
     depends_on("sycl", type=("build", "link", "run"))
     depends_on("dpcpp", when="+onemkl", type=("build", "link", "run"))
     depends_on("cuda", when="+curand", type=("build", "link", "run"))
+    depends_on("hiprand +rocm", when="+hiprand", type=("build", "link", "run"))
     depends_on("googletest@1.10.0:", type=("build", "link", "run"))
     depends_on("cmake@3.24:", type="build")
 
@@ -58,17 +68,6 @@ class NesoRngToolkit(CMakePackage):
         type=("build", "link", "run"),
     )
 
-    depends_on(
-        "cuda",
-        when="^adaptivecpp compilationflow=cudallvm",
-        type=("build", "link", "run"),
-    )
-    depends_on(
-        "cuda",
-        when="^adaptivecpp compilationflow=cudanvcxx",
-        type=("build", "link", "run"),
-    )
-
     def cmake_args(self):
         args = []
 
@@ -78,13 +77,21 @@ class NesoRngToolkit(CMakePackage):
         if "+onemkl" in self.spec:
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_ONEMKL=ON")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")
 
         elif "+curand" in self.spec:
-            args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=ON")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=ON")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")
+
+        elif "+hiprand" in self.spec:
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=ON")
 
         else:
-            args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
+            args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")
 
         return args

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -105,6 +105,7 @@ class NesoRngToolkit(CMakePackage):
         platformsearch = ("+platformsearch" in self.spec) and not (
             "^adaptivecpp compilationflow=omplibraryonly" in self.spec
             or "^adaptivecpp compilationflow=ompaccelerated" in self.spec
+            or "^adaptivecpp compilationflow=generic ~cuda ~rocm" in self.spec
         )
 
         use_onemkl = ("+onemkl" in self.spec) or (

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -74,27 +74,27 @@ class NesoRngToolkit(CMakePackage):
     )
     depends_on(
         "cuda",
-        when="^adaptivecpp compilationflow=cudallvm",
+        when="+platformsearch ^adaptivecpp compilationflow=cudallvm",
         type=("build", "link", "run"),
     )
     depends_on(
         "cuda",
-        when="^adaptivecpp compilationflow=cudanvcxx",
+        when="+platformsearch ^adaptivecpp compilationflow=cudanvcxx",
         type=("build", "link", "run"),
     )
     depends_on(
         "cuda",
-        when="^adaptivecpp compilationflow=generic +cuda",
+        when="+platformsearch ^adaptivecpp compilationflow=generic +cuda",
         type=("build", "link", "run"),
     )
     depends_on(
         "hiprand +rocm",
-        when="^adaptivecpp compilationflow=generic +rocm",
+        when="+platformsearch ^adaptivecpp compilationflow=generic +rocm",
         type=("build", "link", "run"),
     )
     depends_on(
         "hiprand +rocm",
-        when="^adaptivecpp compilationflow=hip",
+        when="+platformsearch ^adaptivecpp compilationflow=hip",
         type=("build", "link", "run"),
     )
 

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -38,6 +38,11 @@ class NesoRngToolkit(CMakePackage):
         default=False,
         description="Enables the hipRAND RNG as a required platform. Disables other platforms.",
     )
+    variant(
+        "platformsearch",
+        default=True,
+        description="Explicitly disables searching for platforms which are not C++ stdlib.",
+    )
     conflicts("+onemkl", when="+curand")
     conflicts("+onemkl", when="+hiprand")
     conflicts("+curand", when="+hiprand")
@@ -67,29 +72,77 @@ class NesoRngToolkit(CMakePackage):
         when="^dpcpp",
         type=("build", "link", "run"),
     )
+    depends_on(
+        "cuda",
+        when="^adaptivecpp compilationflow=cudallvm",
+        type=("build", "link", "run"),
+    )
+    depends_on(
+        "cuda",
+        when="^adaptivecpp compilationflow=cudanvcxx",
+        type=("build", "link", "run"),
+    )
+    depends_on(
+        "cuda",
+        when="^adaptivecpp compilationflow=generic +cuda",
+        type=("build", "link", "run"),
+    )
+    depends_on(
+        "hiprand +rocm",
+        when="^adaptivecpp compilationflow=generic +rocm",
+        type=("build", "link", "run"),
+    )
+    depends_on(
+        "hiprand +rocm",
+        when="^adaptivecpp compilationflow=hip",
+        type=("build", "link", "run"),
+    )
 
     def cmake_args(self):
         args = []
 
-        # If these variants were explicitly specified then we add the CMake
-        # flags which make the discovery of the corresponding platform
-        # mandatory and disable the other platforms.
-        if "+onemkl" in self.spec:
+        platformsearch = ("+platformsearch" in self.spec) and not (
+            "^adaptivecpp compilationflow=omplibraryonly" in self.spec
+            or "^adaptivecpp compilationflow=ompaccelerated" in self.spec
+        )
+        use_onemkl = ("+onemkl" in self.spec) or (
+            platformsearch and ("^dpcpp" in self.spec)
+        )
+        use_curand = ("+curand" in self.spec) or (
+            platformsearch
+            and (
+                "^adaptivecpp compilationflow=cudanvcxx" in self.spec
+                or "^adaptivecpp compilationflow=cudallvm" in self.spec
+                or "^adaptivecpp compilationflow=generic +cuda" in self.spec
+            )
+        )
+        use_hiprand = ("+hiprand" in self.spec) or (
+            platformsearch
+            and (
+                "^adaptivecpp compilationflow=generic +rocm" in self.spec
+                or "^adaptivecpp compilationflow=hip" in self.spec
+            )
+        )
+
+        # If these variants were explicitly specified or expected then we add
+        # the CMake flags which make the discovery of the corresponding
+        # platform mandatory and disable the other platforms.
+        if use_onemkl:
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_ONEMKL=ON")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")
 
-        elif "+curand" in self.spec:
+        elif use_curand:
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=ON")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")
 
-        elif "+hiprand" in self.spec:
+        elif use_hiprand:
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=ON")
 
-        else:
+        if not platformsearch:
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -144,7 +144,7 @@ class NesoRngToolkit(CMakePackage):
             args.append("-DNESO_RNG_TOOLKIT_REQUIRE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=ON")
 
-        if not platformsearch:
+        else:
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_ONEMKL=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_CURAND=OFF")
             args.append("-DNESO_RNG_TOOLKIT_ENABLE_HIPRAND=OFF")

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -106,10 +106,8 @@ class NesoRngToolkit(CMakePackage):
             or "^adaptivecpp compilationflow=ompaccelerated" in self.spec
         )
 
-        use_onemkl = (
-            ("+onemkl" in self.spec)
-            or platformsearch
-            and ("^dpcpp" in self.spec)
+        use_onemkl = ("+onemkl" in self.spec) or (
+            platformsearch and ("^dpcpp" in self.spec)
         )
 
         use_curand = ("+curand" in self.spec) or (

--- a/packages/neso-rng-toolkit/package.py
+++ b/packages/neso-rng-toolkit/package.py
@@ -41,7 +41,7 @@ class NesoRngToolkit(CMakePackage):
     variant(
         "platformsearch",
         default=True,
-        description="Explicitly disables searching for platforms which are not C++ stdlib.",
+        description="Explicitly enables searching for platforms which are not C++ stdlib. Disabling this variant will disable searching for an appropriate platform based on SYCL implementation.",
     )
     conflicts("+onemkl", when="+curand")
     conflicts("+onemkl", when="+hiprand")


### PR DESCRIPTION
* Adds hipRAND variant to NESO-RNG-Toolkit
* Updates how AdaptiveCpp packages depends on the AMD device libraries.
